### PR TITLE
use exit code for failure only

### DIFF
--- a/lib/extract-text.js
+++ b/lib/extract-text.js
@@ -8,7 +8,7 @@ var spawn = require('child_process').spawn;
  * @return {[type]}            [description]
  */
 module.exports.process = function(pdf_path, options, callback) {
-  
+
   var args = [];
   if (typeof options !== 'function') {
     if (options && options.from && !isNaN(options.from)) {
@@ -49,7 +49,7 @@ module.exports.process = function(pdf_path, options, callback) {
     output += data;
   });
 
-  stdout.on('close', function(code) {
+  child.on('close', function(code) {
     if (code) {
       callback('pdftotext end with code ' + code, null);
     }

--- a/lib/extract-text.js
+++ b/lib/extract-text.js
@@ -36,22 +36,22 @@ module.exports.process = function(pdf_path, options, callback) {
   var stdout = child.stdout;
   var stderr = child.stderr;
   var output = '';
+  var errput = '';
 
   stdout.setEncoding('utf8');
   stderr.setEncoding('utf8');
 
+  // buffer both streams
   stderr.on('data', function(data) {
-    return callback(data, null);
+    errput += data;
   });
-
-  // buffer the stdout output
   stdout.on('data', function(data) {
     output += data;
   });
 
   child.on('close', function(code) {
     if (code) {
-      callback('pdftotext end with code ' + code, null);
+      callback('pdftotext end with code ' + code, null, errput);
     }
     callback(null, output);
 

--- a/lib/info.js
+++ b/lib/info.js
@@ -27,7 +27,7 @@ module.exports.process = function(pdf_path, callback) {
     output += data;
   });
 
-  stdout.on('close', function(code) {
+  child.on('close', function(code) {
     if (code) {
       callback('pdfinfo end with code ' + code, null);
     }

--- a/lib/info.js
+++ b/lib/info.js
@@ -13,23 +13,22 @@ module.exports.process = function(pdf_path, callback) {
   var stdout = child.stdout;
   var stderr = child.stderr;
   var output = '';
+  var errput = '';
 
   stdout.setEncoding('utf8');
   stderr.setEncoding('utf8');
 
+  // buffer both streams
   stderr.on('data', function(data) {
-    console.log('data ' + data)
-    return callback(data, null);
+    errput += data;
   });
-
-  // buffer the stdout output
   stdout.on('data', function(data) {
     output += data;
   });
 
   child.on('close', function(code) {
     if (code) {
-      callback('pdfinfo end with code ' + code, null);
+      callback('pdfinfo end with code ' + code, null, errput);
     }
     output = convertOutputToObject(output);
     callback(null, output);


### PR DESCRIPTION
Don't: use the first `stderr` as an indication of failure.
Do: use the exit code as an indication of failure

Because: I've found a PDF which `pdftotext` logs stuff to `stderr` but still produces a good result.

`stderr` now saved to `errput` and given to the `callback` as the third parameter, to maintain BC in case anyone switches flow based on `if (out)` rather than `if (err)`